### PR TITLE
Made things work for Python 3.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ logs
 predictions
 venv
 
+**/.DS_Store
+.python-version
+__pycache__/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,11 @@
+python>=3.11.0,<3.12.0; python_version < '3.11.0'
+python>=3.11.0,<3.12.0; python_version > '3.12.0'
+
+keras>=2.0.0,<3.0.0
 matplotlib>=2.1.0
-pandas>= 0.22.0
+pandas>=0.22.0
 scikit-learn>=0.19.1
 scipy>=1.0.0
 svgwrite>=1.1.12
-tensorflow>=2.15.0
-tensorflow-probability>=0.23.0
+tensorflow>=2.0.0,<2.16.1
+tensorflow-probability<0.24.0


### PR DESCRIPTION
Took me a few hours to get this branch working on my Macbook.  Turned out to require Python 3.11 as the maximum version, and required preventing some breaking changes to a few modules (by modifying requirements.txt).  I made the 3.11 python version very explicit in the requirements.txt file (any non-3.11 will results in an easy to understand error), and added a few additions to the gitignore.